### PR TITLE
customize subdivision names for NZ and ZA

### DIFF
--- a/resources/subdivision/NZ.json
+++ b/resources/subdivision/NZ.json
@@ -29,7 +29,7 @@
 		},
 		"NZ-MBH": {
 			"code": "MBH",
-			"name": "Marl"
+			"name": "Marlborough"
 		},
 		"NZ-MWT": {
 			"code": "MWT",

--- a/resources/subdivision/ZA.json
+++ b/resources/subdivision/ZA.json
@@ -9,7 +9,7 @@
 		},
 		"ZA-FS": {
 			"code": "FS",
-			"name": "Free"
+			"name": "Free State"
 		},
 		"ZA-GT": {
 			"code": "GT",


### PR DESCRIPTION
For South Africa, the state "Free" should be "Free State"

For New Zealand, the state, "Marl" should be "Marlborough"