### PR TITLE
Remove subdivision names for NZ [#159960891]

### DIFF
--- a/resources/subdivision/NZ.json
+++ b/resources/subdivision/NZ.json
@@ -25,7 +25,7 @@
 		},
 		"NZ-HKB": {
 			"code": "HKB",
-			"name": "Hawke’s Bay"
+			"name": "Hawke's Bay"
 		},
 		"NZ-MBH": {
 			"code": "MBH",
@@ -34,10 +34,6 @@
 		"NZ-MWT": {
 			"code": "MWT",
 			"name": "Manawatu-Wanganui"
-		},
-		"NZ-N": {
-			"code": "N",
-			"name": "North Island"
 		},
 		"NZ-NSN": {
 			"code": "NSN",
@@ -50,10 +46,6 @@
 		"NZ-OTA": {
 			"code": "OTA",
 			"name": "Otago"
-		},
-		"NZ-S": {
-			"code": "S",
-			"name": "South Island"
 		},
 		"NZ-STL": {
 			"code": "STL",


### PR DESCRIPTION

From @rbavandla
please remove smart quote from Hawke’s Bay, and replace it with a regular quote.
also i dont think we have to support North Island and South Island, as they are more like a super region over other regions, and they are not mappable to pelias