### PR TITLE
[#188787914] Adding Locality Type 'city' to United Arab Emirates Country

### DIFF
--- a/resources/address_format/AE.json
+++ b/resources/address_format/AE.json
@@ -9,5 +9,6 @@
 	"uppercase_fields": [
 		"locality"
 	],
-	"administrative_area_type": "emirate"
+	"administrative_area_type": "emirate",
+	"locality_type": "city"
 }


### PR DESCRIPTION
PT story: https://www.pivotaltracker.com/n/projects/1533001/stories/188787914

Summary: The label for city is empty when the coutry selected is United Arab Emirates. With this changed, the label 'City' should show.